### PR TITLE
Correct the sysuser path

### DIFF
--- a/rpm/forgejo.sysusers
+++ b/rpm/forgejo.sysusers
@@ -1,3 +1,3 @@
 #Type Name    ID GECOS                  Home directory
 g     git     -
-u     git     -  "Forgejo"              /usr/share/gitea
+u     git     -  "Forgejo"              /usr/share/forgejo


### PR DESCRIPTION
/usr/share/gitea doesn't exist in forgejo package installation. /usr/share/forgejo contains .ssh/ which is necessary for Git over SSH to work.